### PR TITLE
Revert "Merge master changes into feature-branch using `Squash Merge`."

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,2 @@
 # github-mergeflow
 Testing github merge branch workflow
-
-## Problem Statement
-
-1. master branch, stable feature set, disregard the existence of feature branch.
-1. feature branch,  deveop separately, wants to move on independently for now
-   but will merged back to master.
-1. Meanwhile, we want feature branch not diverge too much.

--- a/master-content.txt
+++ b/master-content.txt
@@ -1,3 +1,1 @@
 This is the file checked into master branch.
-
-Line 1


### PR DESCRIPTION
Reverts incfly/github-mergeflow#1

Proved `squash merge` github can't recognize.
1. repo page still show the feature branch fall behind the master
1. When merging feature branch back to master, it can't recognize the changes on `master-content.txt` is already done.